### PR TITLE
Add support for deriving values

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
   - [Quick Start](quick-start.md)
   - [Defining factories](define.md)
   - [Extending factories](extend.md)
+  - [Deriving values](derive.md)
 
 - Recipes
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,17 @@ Uses an existing cooky-cutter factory to create arrays. For examples, see [creat
 | size        | `number`       | Size of the array that will be generated             |
 | **Returns** | `ArrayFactory` | [Array factory function](api#array-factory-function) |
 
+## derive
+
+Derive an attribute's value from other fields in the factory. For examples, see
+[deriving values](derive).
+
+| Param         | Type           | Description                                        |
+| ------------- | -------------- | -------------------------------------------------- |
+| fn            | `Function`     | Receives an object with the dependent keys defined |
+| dependentKeys | `String`       | Attributes the derived field is dependent on       |
+| **Returns**   | Attribute Type | Matches the attribute type                         |
+
 ## Factory function
 
 The return value of `define` and `extend`. It can be invoked any number of times

--- a/docs/derive.md
+++ b/docs/derive.md
@@ -1,0 +1,34 @@
+# Deriving values
+
+The `cooky-cutter` package provides a `derive` method to compute a single value
+and assign it to the attribute based off any number of other attributes defined
+in the factory. This is useful for deriving a fields value off of other dynamic
+field(s) that are not known until a factory is invoked. The order does not
+matter, dependent attributes will be calculated first.
+
+!> A derived field can reference other derived fields, but they **cannot be
+circularly referenced.**
+
+## Usage
+
+### Basic example
+
+```typescript
+type User = {
+  firstName: string;
+  lastName: string;
+  fullName: string;
+};
+
+const user = define<User>({
+  firstName: "Bob",
+  lastName: "Smith",
+  fullName: derive<User, string>(
+    ({ firstName, lastName }) => `${firstName} ${lastName}`,
+    "firstName",
+    "lastName"
+  )
+});
+
+user().fullName; // "Bob Smith"
+```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "check-types": "npm run build --noEmit",
     "check-formatting": "./node_modules/.bin/prettier --list-different \"src/**/*.ts*\"",
     "precommit": "pretty-quick --staged",
-    "coverage": "nyc report --temp-directory=coverage --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --temp-directory=coverage --reporter=text-lcov | coveralls",
+    "docs": "docsify serve docs"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/derive.test.ts
+++ b/src/__tests__/derive.test.ts
@@ -5,7 +5,6 @@ type User = {
   lastName: string;
   fullName: string;
   age: number;
-  admin?: boolean;
 };
 
 describe("derive", () => {

--- a/src/__tests__/derive.test.ts
+++ b/src/__tests__/derive.test.ts
@@ -1,5 +1,7 @@
-import { define, derive, sequence } from "../index";
+import { define, derive, sequence, extend } from "../index";
 
+type Model = { id: number };
+type Post = { title: string } & Model;
 type User = {
   firstName: string;
   lastName: string;
@@ -13,7 +15,7 @@ describe("derive", () => {
       firstName: "Bob",
       lastName: "Smith",
       age: 3,
-      fullName: derive<User, "firstName" | "lastName" | "age", string>(
+      fullName: derive<User, string>(
         ({ firstName, lastName, age }) => `${firstName} ${lastName} ${age}`,
         "firstName",
         "lastName",
@@ -53,13 +55,13 @@ describe("derive", () => {
   test("computes derived attributes dependent on other derived attributes", () => {
     const user = define<User>({
       age: sequence,
-      firstName: derive<User, "age", string>(({ age }) => `Bob ${age}`, "age"),
-      fullName: derive<User, "firstName" | "lastName", string>(
+      firstName: derive<User, string>(({ age }) => `Bob ${age}`, "age"),
+      fullName: derive<User, string>(
         ({ firstName, lastName }) => `${firstName} ${lastName}`,
         "firstName",
         "lastName"
       ),
-      lastName: derive<User, "age", string>(({ age }) => `Smith ${age}`, "age")
+      lastName: derive<User, string>(({ age }) => `Smith ${age}`, "age")
     });
 
     expect(user()).toEqual({
@@ -80,15 +82,15 @@ describe("derive", () => {
   test("throws on circularly derived fields at runtime", () => {
     const user = define<User>({
       age: sequence,
-      fullName: derive<User, "lastName", string>(
+      fullName: derive<User, string>(
         ({ lastName }) => `${lastName}`,
         "lastName"
       ),
-      lastName: derive<User, "firstName", string>(
+      lastName: derive<User, string>(
         ({ firstName }) => `${firstName} Smith`,
         "firstName"
       ),
-      firstName: derive<User, "fullName", string>(
+      firstName: derive<User, string>(
         ({ fullName }) => `Bob ${fullName}`,
         "fullName"
       )

--- a/src/__tests__/derive.test.ts
+++ b/src/__tests__/derive.test.ts
@@ -77,4 +77,28 @@ describe("derive", () => {
       fullName: "Bob 2 Smith 2"
     });
   });
+
+  test("throws on circularly derived fields at runtime", () => {
+    const user = define<User>({
+      age: sequence,
+      fullName: derive<User, "lastName", string>(
+        ({ lastName }) => `${lastName}`,
+        "lastName"
+      ),
+      lastName: derive<User, "firstName", string>(
+        ({ firstName }) => `${firstName} Smith`,
+        "firstName"
+      ),
+      firstName: derive<User, "fullName", string>(
+        ({ fullName }) => `Bob ${fullName}`,
+        "fullName"
+      )
+    });
+
+    expect(() => {
+      user();
+    }).toThrowError(
+      "lastName cannot circularly derive itself. Check along this path: lastName->firstName->fullName->lastName"
+    );
+  });
 });

--- a/src/__tests__/derive.test.ts
+++ b/src/__tests__/derive.test.ts
@@ -31,10 +31,25 @@ describe("derive", () => {
     });
   });
 
+  test("computes derived attributes using extend", () => {
+    const model = define<Model>({
+      id: sequence
+    });
+
+    const post = extend<Model, Post>(model, {
+      title: derive<Post, string>(({ id }) => `Post ${id}`, "id")
+    });
+
+    expect(post()).toEqual({
+      id: 1,
+      title: "Post 1"
+    });
+  });
+
   test("computes derived attributes when dependent attributes have not been evaluated", () => {
     const user = define<User>({
       firstName: "Bob",
-      fullName: derive<User, "firstName" | "lastName" | "age", string>(
+      fullName: derive<User, string>(
         ({ firstName, lastName, age }) => `${firstName} ${lastName} ${age}`,
         "firstName",
         "lastName",

--- a/src/__tests__/derive.test.ts
+++ b/src/__tests__/derive.test.ts
@@ -1,0 +1,55 @@
+import { define } from "../index";
+import { derive } from "../derive";
+
+type User = {
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  age: number;
+  admin?: boolean;
+};
+
+describe("derive", () => {
+  test("can compute derived attributes", () => {
+    const user = define<User>({
+      firstName: "Bob",
+      lastName: "Smith",
+      age: 3,
+      fullName: derive<User, "firstName" | "lastName" | "age", string>(
+        ({ firstName, lastName, age }) => `${firstName} ${lastName} ${age}`,
+        "firstName",
+        "lastName",
+        "age"
+      )
+    });
+
+    expect(user()).toEqual({
+      firstName: "Bob",
+      lastName: "Smith",
+      age: 3,
+      fullName: "Bob Smith 3"
+    });
+  });
+
+  test("can compute derived attributes when dependent attributes are defined later", () => {
+    const user = define<User>({
+      firstName: "Bob",
+      fullName: derive<User, "firstName" | "lastName" | "age", string>(
+        ({ firstName, lastName, age }) => `${firstName} ${lastName} ${age}`,
+        "firstName",
+        "lastName",
+        "age"
+      ),
+      // These attributes have not been "evaluated" yet
+      lastName: "Smith",
+      age: 3
+    });
+
+    expect(user()).toEqual({
+      firstName: "Bob",
+      lastName: "Smith",
+      age: 3,
+      fullName: "Bob Smith 3"
+    });
+  });
+});

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -1,5 +1,9 @@
-import { isFunction, isDerivedFunction } from "./utils";
-import { Config, AttributeFunction } from "./define";
+import {
+  isAttributeFunction,
+  isDerivedFunction,
+  isFactoryFunction
+} from "./utils";
+import { Config } from "./define";
 
 function compute<
   Key extends keyof Result,
@@ -16,11 +20,11 @@ function compute<
 
   if (isDerivedFunction<Result, Result[Key]>(value)) {
     result[key] = value(result, values, invocations, path);
-  } else if (isFunction(value)) {
-    // TODO: find a better way to distinguish AttributeFunction vs Factory
-    result[key] = (value as AttributeFunction<any>)(invocations);
+  } else if (isFactoryFunction<Result[Key]>(value)) {
+    result[key] = value();
+  } else if (isAttributeFunction<Result[Key]>(value)) {
+    result[key] = value(invocations);
   } else {
-    // TODO: Ideally we can avoid this cast.
     result[key] = value as Result[Key];
   }
 }

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -1,0 +1,28 @@
+import { isFunction, isDerivedFunction } from "./utils";
+import { Config, AttributeFunction } from "./define";
+
+function compute<
+  Key extends keyof Result,
+  Values extends Config<Result>,
+  Result
+>(
+  key: Key,
+  values: Values,
+  result: Result,
+  invocations: number,
+  path: Key[] = []
+) {
+  const value = values[key];
+
+  if (isDerivedFunction<Result, Result[Key]>(value)) {
+    result[key] = value(result, values, invocations, path);
+  } else if (isFunction(value)) {
+    // TODO: find a better way to distinguish AttributeFunction vs Factory
+    result[key] = (value as AttributeFunction<any>)(invocations);
+  } else {
+    // TODO: Ideally we can avoid this cast.
+    result[key] = value as Result[Key];
+  }
+}
+
+export { compute };

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -5,6 +5,10 @@ import {
 } from "./utils";
 import { Config } from "./define";
 
+// Given a key, the configuration object (with overrides already applied) and
+// the end result object, compute the current value for the given key and write
+// that value to the result object. Optionally track the path values are
+// computed along in cases where it's possible to define circular dependencies.
 function compute<
   Key extends keyof Result,
   Values extends Config<Result>,
@@ -18,6 +22,9 @@ function compute<
 ) {
   const value = values[key];
 
+  // In essence, this is "exhaustively" checking for each type of attribute that
+  // can be defined for a given key. Unfortunately it's not truly exhaustive,
+  // but would be great to update this to do true exhaustive type checking.
   if (isDerivedFunction<Result, Result[Key]>(value)) {
     result[key] = value(result, values, invocations, path);
   } else if (isFactoryFunction<Result[Key]>(value)) {

--- a/src/define.ts
+++ b/src/define.ts
@@ -27,7 +27,7 @@ type Factory<T> = (override?: FactoryConfig<T>) => T;
 function define<Result>(config: Config<Result>): Factory<Result> {
   let invocations = 0;
 
-  return (override = {}) => {
+  const factory = (override = {}) => {
     invocations++;
 
     let result = {} as Result;
@@ -39,6 +39,14 @@ function define<Result>(config: Config<Result>): Factory<Result> {
 
     return result;
   };
+
+  // Define a property to differentiate this function during the evaluation
+  // phase when the factory is later invoked.
+  Object.defineProperty(factory, "__cooky-cutter-factory", {
+    value: true
+  });
+
+  return factory;
 }
 
 export { define, AttributeFunction, Config, Factory, FactoryConfig };

--- a/src/define.ts
+++ b/src/define.ts
@@ -1,5 +1,5 @@
-import { isFunction, isDerivedFunction } from "./utils";
 import { DerivedFunction } from "./derive";
+import { compute } from "./compute";
 
 type Config<T> = {
   [Key in keyof T]:
@@ -29,8 +29,8 @@ function define<Result>(config: Config<Result>): Factory<Result> {
 
   return (override = {}) => {
     invocations++;
-    let result = {} as Result;
 
+    let result = {} as Result;
     const values = Object.assign({}, config, override);
 
     for (let key in values) {
@@ -41,28 +41,4 @@ function define<Result>(config: Config<Result>): Factory<Result> {
   };
 }
 
-function compute<
-  Key extends keyof Result,
-  Values extends Config<Result>,
-  Result
->(
-  key: Key,
-  values: Values,
-  result: Result,
-  invocations: number,
-  path: Key[] = []
-) {
-  const value = values[key];
-
-  if (isDerivedFunction<Result, Result[Key]>(value)) {
-    result[key] = value(result, values, invocations, path);
-  } else if (isFunction(value)) {
-    // TODO: find a better way to distinguish AttributeFunction vs Factory
-    result[key] = (value as AttributeFunction<any>)(invocations);
-  } else {
-    // TODO: Ideally we can avoid this cast.
-    result[key] = value as Result[Key];
-  }
-}
-
-export { define, compute, AttributeFunction, Config, Factory, FactoryConfig };
+export { define, AttributeFunction, Config, Factory, FactoryConfig };

--- a/src/define.ts
+++ b/src/define.ts
@@ -45,11 +45,17 @@ function compute<
   Key extends keyof Result,
   Values extends Config<Result>,
   Result
->(key: Key, values: Values, result: Result, invocations: number) {
+>(
+  key: Key,
+  values: Values,
+  result: Result,
+  invocations: number,
+  path: Key[] = []
+) {
   const value = values[key];
 
   if (isDerivedFunction<Result, Result[Key]>(value)) {
-    result[key] = value(result, values, invocations);
+    result[key] = value(result, values, invocations, path);
   } else if (isFunction(value)) {
     // TODO: find a better way to distinguish AttributeFunction vs Factory
     result[key] = (value as AttributeFunction<any>)(invocations);

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -1,4 +1,10 @@
-type DerivedFunction<Base, Output> = (result: Base) => Output;
+import { compute, Config } from "./define";
+
+type DerivedFunction<Base, Output> = (
+  result: Base,
+  values: Config<Base>,
+  invocations: number
+) => Output;
 
 type InputObject<Base, InputKeys extends keyof Base> = {
   [Key in InputKeys]: Base[Key]
@@ -8,12 +14,22 @@ function derive<Base, InputKeys extends keyof Base, Output>(
   fn: (input: InputObject<Base, InputKeys>) => Output,
   ...dependentKeys: InputKeys[]
 ): DerivedFunction<Base, Output> {
-  const derivedFunction = (config: Base): Output => {
+  const derivedFunction: DerivedFunction<Base, Output> = (
+    result,
+    values,
+    invocations
+  ) => {
     // Construct the input object from all of the dependent values that are
     // needed to derive the value.
     const input = dependentKeys.reduce<InputObject<Base, InputKeys>>(
       (input, key) => {
-        input[key] = config[key];
+        // Verify the derived value has been computed, otherwise compute any
+        // derived values before continuing.
+        if (!result.hasOwnProperty(key)) {
+          compute(key, values, result, invocations);
+        }
+
+        input[key] = result[key];
         return input;
       },
       {} as InputObject<Base, InputKeys>

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -1,4 +1,5 @@
-import { compute, Config } from "./define";
+import { Config } from "./define";
+import { compute } from "./compute";
 
 type DerivedFunction<Base, Output> = (
   result: Base,

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -1,0 +1,34 @@
+type DerivedFunction<Base, Output> = (result: Base) => Output;
+
+type InputObject<Base, InputKeys extends keyof Base> = {
+  [Key in InputKeys]: Base[Key]
+};
+
+function derive<Base, InputKeys extends keyof Base, Output>(
+  fn: (input: InputObject<Base, InputKeys>) => Output,
+  ...dependentKeys: InputKeys[]
+): DerivedFunction<Base, Output> {
+  const derivedFunction = (config: Base): Output => {
+    // Construct the input object from all of the dependent values that are
+    // needed to derive the value.
+    const input = dependentKeys.reduce<InputObject<Base, InputKeys>>(
+      (input, key) => {
+        input[key] = config[key];
+        return input;
+      },
+      {} as InputObject<Base, InputKeys>
+    );
+
+    return fn(input);
+  };
+
+  // Define a property to differentiate this function during the evaluation
+  // phase when the factory is later invoked.
+  Object.defineProperty(derivedFunction, "__cooky-cutter-derive", {
+    value: true
+  });
+
+  return derivedFunction;
+}
+
+export { derive, DerivedFunction };

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -8,13 +8,9 @@ type DerivedFunction<Base, Output> = (
   path: (keyof Base)[]
 ) => Output;
 
-type InputObject<Base, InputKeys extends keyof Base> = {
-  [Key in InputKeys]: Base[Key]
-};
-
-function derive<Base, InputKeys extends keyof Base, Output>(
-  fn: (input: InputObject<Base, InputKeys>) => Output,
-  ...dependentKeys: InputKeys[]
+function derive<Base, Output>(
+  fn: (input: Partial<Base>) => Output,
+  ...dependentKeys: (keyof Base)[]
 ): DerivedFunction<Base, Output> {
   const derivedFunction: DerivedFunction<Base, Output> = (
     result,
@@ -24,7 +20,7 @@ function derive<Base, InputKeys extends keyof Base, Output>(
   ) => {
     // Construct the input object from all of the dependent values that are
     // needed to derive the value.
-    const input = dependentKeys.reduce<InputObject<Base, InputKeys>>(
+    const input = dependentKeys.reduce<Partial<Base>>(
       (input, key) => {
         // Verify the derived value has been computed, otherwise compute any
         // derived values before continuing.
@@ -43,7 +39,7 @@ function derive<Base, InputKeys extends keyof Base, Output>(
         input[key] = result[key];
         return input;
       },
-      {} as InputObject<Base, InputKeys>
+      {} as Partial<Base>
     );
 
     return fn(input);

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -8,6 +8,19 @@ type DerivedFunction<Base, Output> = (
   path: (keyof Base)[]
 ) => Output;
 
+/**
+ * Compute a single value and assign it to the attribute based off any number
+ * of other attributes defined in the factory. This is useful for deriving a
+ * fields value off of other dynamic field(s) that are not known until a factory
+ * is invoked. A derived field can reference other derived fields, but they
+ * cannot be circularly referenced.
+ *
+ * @param fn a function to reduce all of the dependent keys into a single
+ * dervied value. The return value will be assigned to the attribute.
+ * @param dependentKeys a list of all keys that the derive function is dependent
+ * on. If the key is not defined in this list, it is not guaranteed to be
+ * defined.
+ */
 function derive<Base, Output>(
   fn: (input: Partial<Base>) => Output,
   ...dependentKeys: (keyof Base)[]

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -1,4 +1,4 @@
-import { Factory, FactoryConfig, AttributeFunction } from "./index";
+import { Factory, FactoryConfig, AttributeFunction, Config } from "./index";
 import { DiffProperties } from "./utils";
 import { compute } from "./compute";
 import { DerivedFunction } from "./derive";
@@ -40,24 +40,16 @@ function extend<Base, Result extends Base>(
     invocations++;
     let result = base(override as FactoryConfig<Base>) as Result;
 
-    for (let k in config) {
-      // TODO: the type of k is not properly inferred
-      let key = k as Extract<keyof Result, string>;
-      const value = override.hasOwnProperty(key)
-        ? override[key]
-        : config[key as string];
+    // TODO: this cast is necessary for the correct `key` typings and playing
+    // nice with `compute`. Ideally, this can be avoided.
+    const values = Object.assign({}, config, override) as Config<Result>;
 
-      if (isAttributeFunction(value)) {
-        // TODO: find a better way to distinguish AttributeFunction vs Factory
-        result[key] = (value as AttributeFunction<any>)(invocations);
-      } else {
-        // TODO: Ideally we can avoid this cast.
-        result[key] = value as Result[Extract<keyof Result, string>];
-      }
+    for (let key in values) {
+      compute(key, values, result, invocations);
     }
 
     return result;
   };
 }
 
-export { extend };
+export { extend, ExtendConfig };

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -1,5 +1,5 @@
 import { Factory, Config, FactoryConfig, AttributeFunction } from "./index";
-import { isFunction, DiffProperties } from "./utils";
+import { isAttributeFunction, DiffProperties } from "./utils";
 
 /**
  * Define a new factory function from an existing fatory. The return value is a
@@ -29,7 +29,7 @@ function extend<Base, Result extends Base>(
         ? override[key]
         : config[key as string];
 
-      if (isFunction(value)) {
+      if (isAttributeFunction(value)) {
         // TODO: find a better way to distinguish AttributeFunction vs Factory
         result[key] = (value as AttributeFunction<any>)(invocations);
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@ export {
   FactoryConfig
 } from "./define";
 export { extend } from "./extend";
+export { derive } from "./derive";
 export { random, sequence } from "./helpers";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ export {
   Factory,
   FactoryConfig
 } from "./define";
-export { extend } from "./extend";
+export { extend, ExtendConfig } from "./extend";
 export { derive } from "./derive";
 export { random, sequence } from "./helpers";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,20 +1,18 @@
 import { DerivedFunction } from "./derive";
-
-/**
- * Type guard funciton to determine if the argument passed is a function.
- *
- * @param functionToCheck value to check if it is a function
- */
-const isFunction = (functionToCheck: any): functionToCheck is Function => {
-  return (
-    functionToCheck && {}.toString.call(functionToCheck) === "[object Function]"
-  );
-};
+import { Factory, AttributeFunction } from "./define";
 
 function isDerivedFunction<Base, Output>(
   fn: any
 ): fn is DerivedFunction<Base, Output> {
   return fn && fn.hasOwnProperty("__cooky-cutter-derive");
+}
+
+function isFactoryFunction<Base>(fn: any): fn is Factory<Base> {
+  return fn && fn.hasOwnProperty("__cooky-cutter-factory");
+}
+
+function isAttributeFunction<T>(fn: any): fn is AttributeFunction<T> {
+  return fn && {}.toString.call(fn) === "[object Function]";
 }
 
 // Returns a union of the keys.
@@ -31,4 +29,9 @@ type Diff<T, U> = T extends U ? never : T;
 // into `{ b: number; }`
 type DiffProperties<T, U> = Pick<T, Diff<Keys<T>, Keys<U>>>;
 
-export { isFunction, isDerivedFunction, DiffProperties };
+export {
+  isAttributeFunction,
+  isDerivedFunction,
+  isFactoryFunction,
+  DiffProperties
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { DerivedFunction } from "./derive";
+
 /**
  * Type guard funciton to determine if the argument passed is a function.
  *
@@ -8,6 +10,12 @@ const isFunction = (functionToCheck: any): functionToCheck is Function => {
     functionToCheck && {}.toString.call(functionToCheck) === "[object Function]"
   );
 };
+
+function isDerivedFunction<Base, Output>(
+  fn: any
+): fn is DerivedFunction<Base, Output> {
+  return fn && fn.hasOwnProperty("__cooky-cutter-derive");
+}
 
 // Returns a union of the keys.
 // e.g. it will convert `{ a: {}, b: {} }` into `"a" | "b"`
@@ -23,4 +31,4 @@ type Diff<T, U> = T extends U ? never : T;
 // into `{ b: number; }`
 type DiffProperties<T, U> = Pick<T, Diff<Keys<T>, Keys<U>>>;
 
-export { isFunction, DiffProperties };
+export { isFunction, isDerivedFunction, DiffProperties };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,24 @@
 import { DerivedFunction } from "./derive";
 import { Factory, AttributeFunction } from "./define";
 
+// Determine if the function is an internal derive function based on properties
+// define on the function.
 function isDerivedFunction<Base, Output>(
   fn: any
 ): fn is DerivedFunction<Base, Output> {
   return fn && fn.hasOwnProperty("__cooky-cutter-derive");
 }
 
+// Determine if the function is an internal factory function based on properties
+// define on the function.
 function isFactoryFunction<Base>(fn: any): fn is Factory<Base> {
   return fn && fn.hasOwnProperty("__cooky-cutter-factory");
 }
 
+// Determine if the function is an attribute function. Since this is end-user
+// defined there is not a great way to know for sure if it exactly matches
+// an attribute function, but this is a best guess. This should be used after
+// all other function type checks.
 function isAttributeFunction<T>(fn: any): fn is AttributeFunction<T> {
   return fn && {}.toString.call(fn) === "[object Function]";
 }


### PR DESCRIPTION
Allow deriving values in a factory from other values.

## Use Case

A very simple example:
```ts
{
  firstName: "Bob",
  lastName: "Smith",
  fullName: "Bob Smith" // <-- this field should be `${firstName} ${lastName}`
}
```

## Scenarios

1. Using `derive` should be allowed anywhere in the config object (for example, `fullName` should be able to be defined above `firstName` and/or `lastName`, which means those values need to be computed before the derived function can be).
1. `derive` should be allowed to be depended on other derived attribute(s) limitlessly,
1.  **Except** any circularly dependent `derive` attributes should be caught and error at runtime to avoid infinite recursion
1. As strongly typed as possible (taking into account the end user API) 