### PR TITLE
Update Array docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@
 
 You need to write maintainable tests for JavaScript that depends on a
 specific data model. Plain objects work at first, then maybe factory functions,
-but after a while the data model and the factories get out of sync. A new column 
-gets added, an old one gets removed or maybe an entirely new entity is added. 
-The breaking change isn't noticed until the entire test suite runs (or maybe 
+but after a while the data model and the factories get out of sync. A new column
+gets added, an old one gets removed or maybe an entirely new entity is added.
+The breaking change isn't noticed until the entire test suite runs (or maybe
 never).
 
 **cooky-cutter** is a light, simple package that leverages TypeScript to define
@@ -17,6 +17,7 @@ your factory. When the types change, the factories become invalid!
 
 - 🤖 [Define](define) factories
 - ⚙️ [Extend](extend) existing factories
+- 📦 [Arrays](array) of factories
 - 🚀 [Helpers](helpers) for common patterns
 - ⚡️️ Type safety!
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
   - [Quick Start](quick-start.md)
   - [Defining factories](define.md)
   - [Extending factories](extend.md)
+  - [Arrays of factories](array.md)
   - [Deriving values](derive.md)
 
 - Recipes

--- a/docs/array.md
+++ b/docs/array.md
@@ -1,0 +1,38 @@
+# Arrays of factories
+
+The `cooky-cutter` package provides an `array` method to create a generator
+function to return an array of objects matching the provided factory definition.
+The generator accepts a [configuration object](api#configuration-object)
+to override the underlying factories. Each generator invocation returns a new
+array with new objects matching the factory and optional config.
+
+## Usage
+
+### Creating an array of factories
+
+In this example we will use `User` factory to create arrays of various size.
+
+```typescript
+type User = { firstName: string; age: number };
+
+const user = define<User>({
+  firstName: "Bob",
+  age: 42
+});
+
+const pairOfUsers = array(user, 2);
+
+const trioOfUsers = array(user, 3);
+
+pairOfUsers(); // returns an array of two user objects
+trioOfUsers(); // returns an array of three user objects
+```
+
+### Overriding an array of factories
+
+Similar to the [define method](define) the array generator accepts a config
+to override the underlying factories.
+
+```typescript
+pairOfUsers({ firstName: "Joe" }); // return an array of two user object with the `firstName` "Joe"
+```

--- a/docs/define.md
+++ b/docs/define.md
@@ -63,21 +63,3 @@ const post = define<Post>({
 ?> **TIP:** Name factories the same as attributes that reference that type to leverage
 [ES6 Object Punning](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#New_notations_in_ECMAScript_2015).
 For example, the user factory above.
-
-### Creating array of objects
-
-Lastly, factories can be used to create an array of objects. This is done by using `array` helper function.
-In this example we will use `User` factory to create arrays of various size.
-
-```typescript
-type User = { firstName: string; age: number };
-
-const user = define<User>({
-  firstName: "Bob",
-  age: 42
-});
-
-const pairOfUsers = array(user, 2);
-
-const trioOfUsers = array(user, 3);
-```


### PR DESCRIPTION
- Missing docs on overriding `array` generators
- Moved to their own section so it's not lost in the `define` docs
- Added `array` to the README (first page) as a feature