### PR TITLE
Upgrade to TypeScript 3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7513,9 +7513,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.0-rc.20180911",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.0-rc.20180911.tgz",
-      "integrity": "sha512-q6WeNUmkB6GNKftShDNLr9/aBSCVEFQ+8PF9/DwF/EswfCj1l6BmxtDU8s8eFlmgOmwOqBLaYdut6BEjvnzYVg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7513,9 +7513,9 @@
       }
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.1.0-rc.20180911",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.0-rc.20180911.tgz",
+      "integrity": "sha512-q6WeNUmkB6GNKftShDNLr9/aBSCVEFQ+8PF9/DwF/EswfCj1l6BmxtDU8s8eFlmgOmwOqBLaYdut6BEjvnzYVg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "prettier": "1.13.7",
     "pretty-quick": "^1.6.0",
     "ts-jest": "^22.4.6",
-    "typescript": "rc"
+    "typescript": "^3.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "prettier": "1.13.7",
     "pretty-quick": "^1.6.0",
     "ts-jest": "^22.4.6",
-    "typescript": "^3.0.1"
+    "typescript": "rc"
   }
 }

--- a/src/define.ts
+++ b/src/define.ts
@@ -19,7 +19,12 @@ type AttributeFunction<T> = (invocation: number) => T;
 
 type FactoryConfig<T> = Partial<Config<T>>;
 
-type Factory<T> = (override?: FactoryConfig<T>) => T;
+const FACTORY_FUNCTION_KEY = "factory";
+
+interface Factory<T> {
+  (override?: FactoryConfig<T>): T;
+  __cooky_cutter: typeof FACTORY_FUNCTION_KEY;
+}
 
 /**
  * Define a new factory function. The return value is a function that can be
@@ -48,11 +53,16 @@ function define<Result>(config: Config<Result>): Factory<Result> {
 
   // Define a property to differentiate this function during the evaluation
   // phase when the factory is later invoked.
-  Object.defineProperty(factory, "__cooky-cutter-factory", {
-    value: true
-  });
+  factory.__cooky_cutter = "factory" as typeof FACTORY_FUNCTION_KEY;
 
   return factory;
 }
 
-export { define, AttributeFunction, Config, Factory, FactoryConfig };
+export {
+  define,
+  AttributeFunction,
+  Config,
+  Factory,
+  FactoryConfig,
+  FACTORY_FUNCTION_KEY
+};

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -1,12 +1,17 @@
 import { Config } from "./define";
 import { compute } from "./compute";
 
-type DerivedFunction<Base, Output> = (
-  result: Base,
-  values: Config<Base>,
-  invocations: number,
-  path: (keyof Base)[]
-) => Output;
+const DERIVE_FUNCTION_KEY = "derived";
+
+interface DerivedFunction<Base, Output> {
+  (
+    result: Base,
+    values: Config<Base>,
+    invocations: number,
+    path: (keyof Base)[]
+  ): Output;
+  __cooky_cutter: typeof DERIVE_FUNCTION_KEY;
+}
 
 /**
  * Compute a single value and assign it to the attribute based off any number
@@ -25,12 +30,12 @@ function derive<Base, Output>(
   fn: (input: Partial<Base>) => Output,
   ...dependentKeys: (keyof Base)[]
 ): DerivedFunction<Base, Output> {
-  const derivedFunction: DerivedFunction<Base, Output> = (
+  const derivedFunction: DerivedFunction<Base, Output> = function(
     result,
     values,
     invocations,
     path
-  ) => {
+  ) {
     // Construct the input object from all of the dependent values that are
     // needed to derive the value.
     const input = dependentKeys.reduce<Partial<Base>>(
@@ -60,11 +65,9 @@ function derive<Base, Output>(
 
   // Define a property to differentiate this function during the evaluation
   // phase when the factory is later invoked.
-  Object.defineProperty(derivedFunction, "__cooky-cutter-derive", {
-    value: true
-  });
+  derivedFunction.__cooky_cutter = DERIVE_FUNCTION_KEY as typeof DERIVE_FUNCTION_KEY;
 
   return derivedFunction;
 }
 
-export { derive, DerivedFunction };
+export { derive, DerivedFunction, DERIVE_FUNCTION_KEY };

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -2,6 +2,7 @@ import { Factory, FactoryConfig, AttributeFunction, Config } from "./index";
 import { DiffProperties } from "./utils";
 import { compute } from "./compute";
 import { DerivedFunction } from "./derive";
+import { FACTORY_FUNCTION_KEY } from "./define";
 
 // Helper specific to extending factories. Any keys required in the base type
 // should be optional in the result config because they've already been defined
@@ -36,7 +37,7 @@ function extend<Base, Result extends Base>(
 ): Factory<Result> {
   let invocations = 0;
 
-  return (override = {}) => {
+  const factory = (override = {}) => {
     invocations++;
     let result = base(override as FactoryConfig<Base>) as Result;
 
@@ -50,6 +51,12 @@ function extend<Base, Result extends Base>(
 
     return result;
   };
+
+  // Define a property to differentiate this function during the evaluation
+  // phase when the factory is later invoked.
+  factory.__cooky_cutter = "factory" as typeof FACTORY_FUNCTION_KEY;
+
+  return factory;
 }
 
 export { extend, ExtendConfig };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,18 @@
-import { DerivedFunction } from "./derive";
-import { Factory, AttributeFunction } from "./define";
+import { DerivedFunction, DERIVE_FUNCTION_KEY } from "./derive";
+import { Factory, AttributeFunction, FACTORY_FUNCTION_KEY } from "./define";
 
 // Determine if the function is an internal derive function based on properties
-// define on the function.
+// defined on the function.
 function isDerivedFunction<Base, Output>(
   fn: any
 ): fn is DerivedFunction<Base, Output> {
-  return fn && fn.hasOwnProperty("__cooky-cutter-derive");
+  return fn && fn.__cooky_cutter === DERIVE_FUNCTION_KEY;
 }
 
 // Determine if the function is an internal factory function based on properties
-// define on the function.
+// defined on the function.
 function isFactoryFunction<Base>(fn: any): fn is Factory<Base> {
-  return fn && fn.hasOwnProperty("__cooky-cutter-factory");
+  return fn && fn.__cooky_cutter === FACTORY_FUNCTION_KEY;
 }
 
 // Determine if the function is an attribute function. Since this is end-user


### PR DESCRIPTION
- [TypeScript 3.1 RC Announcement](https://blogs.msdn.microsoft.com/typescript/2018/09/13/announcing-typescript-3-1-rc)
- Upgrade to TypeScript `3.1 RC` 
- Replace the custom `defineProperty` calls with the new first class support for function properties

