### PR TITLE
Warn (by default) or error (opt-in) when a hard-coded value is set

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "test",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- By default, warnings will now be show for hard-coded objects and arrays [#12](https://github.com/skovy/cooky-cutter/pull/12)
+- A `configure` function was added to globally configure factories [#12](https://github.com/skovy/cooky-cutter/pull/12)
+- A configuration option `errorOnHardCodedValues` will throw (rather than warn) about hard-coded values [#12](https://github.com/skovy/cooky-cutter/pull/12)
 - Properly ignore `.vscode` config when publishing to npm in [#9](https://github.com/skovy/cooky-cutter/pull/9)
+
+## Fixed
+
+- The `array` type definitions now match the `extend` type definitions [#12](https://github.com/skovy/cooky-cutter/pull/12)
 
 ## [1.2.0] - 2018-11-10
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,9 +450,18 @@
       }
     },
     "@types/jest": {
-      "version": "23.1.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.1.1.tgz",
-      "integrity": "sha512-x3zfj6ZjmmhoQK9FjBNZN7j5xDQ+Dd2VpxGdll74WUEF8NmTIYSaZTMbzsB5lqNuReuyC75695wM/cNKoJomZA==",
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.13.tgz",
+      "integrity": "sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==",
+      "dev": true,
+      "requires": {
+        "@types/jest-diff": "*"
+      }
+    },
+    "@types/jest-diff": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
+      "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://skovy.github.io/cooky-cutter/",
   "devDependencies": {
-    "@types/jest": "^23.1.1",
+    "@types/jest": "^24.0.0",
     "coveralls": "^3.0.2",
     "husky": "^0.14.3",
     "jest": "^24.8.0",

--- a/src/__tests__/array.test.ts
+++ b/src/__tests__/array.test.ts
@@ -1,9 +1,11 @@
-import { define, random, sequence } from "../index";
+import { define, random, sequence, extend } from "../index";
 import { array } from "../array";
 
 type User = { firstName: string; age: number; admin?: boolean };
 type Post = { title: string; user: User };
 type UsersCollection = { users: User[]; role: string };
+type Model = { id: number };
+type Thing = { id: number; name: string; users: User[] };
 
 describe("array", () => {
   test("returns array with 5 elements by default", () => {
@@ -104,5 +106,26 @@ describe("array", () => {
 
     expect(moderators().users.length).toBe(2);
     expect(moderators({ users: array(user, 3) }).users.length).toBe(3);
+  });
+
+  test("allows extending an existing factory and use an arrow factory", () => {
+    const model = define<Model>({
+      id: sequence
+    });
+
+    const user = define<User>({
+      age: random,
+      firstName: "Mike"
+    });
+
+    const thing = extend<Model, Thing>(model, {
+      name: "Some Thing",
+      users: array(user, 3)
+    });
+
+    const value = thing();
+    expect(value.id).toBe(1);
+    expect(value.name).toBe("Some Thing");
+    expect(value.users).toHaveLength(3);
   });
 });

--- a/src/__tests__/define.test.ts
+++ b/src/__tests__/define.test.ts
@@ -220,9 +220,48 @@ describe("define", () => {
       expect(post().tags).toEqual(["popular", "trending", "YOLO"]);
     });
 
+    test("does not warn about objects or arrays as overrides", () => {
+      const user = define<User>({
+        firstName: "Bob",
+        age: 42
+      });
+
+      const post = define<Post>({
+        title: "The Best Post Ever",
+        user
+      });
+
+      const firstPost = post({
+        user: {
+          firstName: "Hard-coded",
+          age: 1
+        },
+        tags: ["popular", "trending"]
+      });
+
+      expect(firstPost).toEqual({
+        title: "The Best Post Ever",
+        user: {
+          firstName: "Hard-coded",
+          age: 1
+        },
+        tags: ["popular", "trending"]
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     describe("with errorOnHardCodedValues enabled", () => {
+      let traceSpy: jest.SpyInstance;
+
       beforeEach(() => {
         configure({ errorOnHardCodedValues: true });
+
+        traceSpy = jest.spyOn(console, "trace").mockImplementation();
+      });
+
+      afterEach(() => {
+        traceSpy.mockRestore();
       });
 
       test("throws about objects", () => {
@@ -239,6 +278,7 @@ describe("define", () => {
         }).toThrow(
           "`user` contains a hard-coded object. It will be shared across all instances of this factory. Consider using a factory function."
         );
+        expect(traceSpy).toHaveBeenCalled();
       });
 
       test("throws about arrays", () => {
@@ -258,6 +298,7 @@ describe("define", () => {
         }).toThrow(
           "`tags` contains a hard-coded array. It will be shared across all instances of this factory. Consider using a factory function."
         );
+        expect(traceSpy).toHaveBeenCalled();
       });
     });
   });

--- a/src/__tests__/define.test.ts
+++ b/src/__tests__/define.test.ts
@@ -1,4 +1,5 @@
 import { define } from "../index";
+import { configure } from "../";
 
 type User = { firstName: string; age: number; admin?: boolean };
 type Post = { title: string; user: User; tags?: string[] };
@@ -217,6 +218,47 @@ describe("define", () => {
       // When this warning is ignored, this will be the "expected" (accepted) behavior.
       firstPost.tags!.push("YOLO");
       expect(post().tags).toEqual(["popular", "trending", "YOLO"]);
+    });
+
+    describe("with errorOnHardCodedValues enabled", () => {
+      beforeEach(() => {
+        configure({ errorOnHardCodedValues: true });
+      });
+
+      test("throws about objects", () => {
+        const post = define<Post>({
+          title: "The Best Post Ever",
+          user: {
+            firstName: "Hard-coded",
+            age: 1
+          }
+        });
+
+        expect(() => {
+          post();
+        }).toThrow(
+          "`user` contains a hard-coded object. It will be shared across all instances of this factory. Consider using a factory function."
+        );
+      });
+
+      test("throws about arrays", () => {
+        const user = define<User>({
+          firstName: "Bob",
+          age: 42
+        });
+
+        const post = define<Post>({
+          title: "The Best Post Ever",
+          user,
+          tags: ["popular", "trending"]
+        });
+
+        expect(() => {
+          post();
+        }).toThrow(
+          "`tags` contains a hard-coded array. It will be shared across all instances of this factory. Consider using a factory function."
+        );
+      });
     });
   });
 });

--- a/src/__tests__/define.test.ts
+++ b/src/__tests__/define.test.ts
@@ -1,10 +1,20 @@
 import { define } from "../index";
 
 type User = { firstName: string; age: number; admin?: boolean };
-type Post = { title: string; user: User };
+type Post = { title: string; user: User; tags?: string[] };
 
 describe("define", () => {
-  test("handles hardcoded attributes", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("handles hard-coded attributes", () => {
     const user = define<User>({
       firstName: "Bob",
       age: 42
@@ -14,6 +24,8 @@ describe("define", () => {
       firstName: "Bob",
       age: 42
     });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("handles functional attributes", () => {
@@ -26,6 +38,8 @@ describe("define", () => {
       firstName: "Bob",
       age: 42
     });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("returns a factory that returns a new instance each invocation", () => {
@@ -38,6 +52,8 @@ describe("define", () => {
     const secondInvocation = user();
 
     expect(firstInvocation).not.toBe(secondInvocation);
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("passes the number of invocations to functional attributes", () => {
@@ -63,6 +79,8 @@ describe("define", () => {
       firstName: "Bob #3",
       age: 126
     });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("handles nested factories", () => {
@@ -83,6 +101,8 @@ describe("define", () => {
         age: 42
       }
     });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("allows overriding the initial config", () => {
@@ -105,6 +125,8 @@ describe("define", () => {
       firstName: "Jill",
       age: 43
     });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("allows defining optional attributes as overrides", () => {
@@ -118,6 +140,8 @@ describe("define", () => {
       age: 42,
       admin: true
     });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   test("allows overriding with 'falsy' values", () => {
@@ -131,6 +155,68 @@ describe("define", () => {
       firstName: undefined,
       admin: false,
       age: 0
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  describe("hard-coded values", () => {
+    test("warns about objects", () => {
+      const post = define<Post>({
+        title: "The Best Post Ever",
+        user: {
+          firstName: "Hard-coded",
+          age: 1
+        }
+      });
+
+      const firstPost = post();
+      expect(firstPost).toEqual({
+        title: "The Best Post Ever",
+        user: {
+          firstName: "Hard-coded",
+          age: 1
+        }
+      });
+
+      expect(warnSpy).toBeCalledWith(
+        "`user` contains a hard-coded object. It will be shared across all instances of this factory. Consider using a factory function."
+      );
+
+      // When this warning is ignored, this will be the "expected" (accepted) behavior.
+      firstPost.user.firstName = "Joe";
+      expect(post().user.firstName).toEqual("Joe");
+    });
+
+    test("warns about arrays", () => {
+      const user = define<User>({
+        firstName: "Bob",
+        age: 42
+      });
+
+      const post = define<Post>({
+        title: "The Best Post Ever",
+        user,
+        tags: ["popular", "trending"]
+      });
+
+      const firstPost = post();
+      expect(firstPost).toEqual({
+        title: "The Best Post Ever",
+        tags: ["popular", "trending"],
+        user: {
+          firstName: "Bob",
+          age: 42
+        }
+      });
+
+      expect(warnSpy).toBeCalledWith(
+        "`tags` contains a hard-coded array. It will be shared across all instances of this factory. Consider using a factory function."
+      );
+
+      // When this warning is ignored, this will be the "expected" (accepted) behavior.
+      firstPost.tags!.push("YOLO");
+      expect(post().tags).toEqual(["popular", "trending", "YOLO"]);
     });
   });
 });

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,6 +1,10 @@
 import { Factory, FactoryConfig } from "./define";
 
-type ArrayFactory<T> = (override?: FactoryConfig<T>) => T[];
+export type ArrayFactory<T> = (override?: FactoryConfig<T>) => T[];
+
+export type ArrayFactoryPassThrough<T> = (override?: FactoryConfig<T>) => T;
+
+export const ARRAY_FACTORY_KEY = "arrayFactory";
 
 /**
  * Define a new array factory function. The return value is a function that can be
@@ -10,17 +14,21 @@ type ArrayFactory<T> = (override?: FactoryConfig<T>) => T[];
  * @param size Size of target array can either be a static value or a function that receives the
  * invocation count as the only parameter.
  */
-function array<Result>(
+export function array<Result>(
   factory: Factory<Result>,
   size: number = 5
 ): ArrayFactory<Result> {
-  return (override?: FactoryConfig<Result>) => {
+  const arrayFactory = (override?: FactoryConfig<Result>) => {
     const arr = [];
     for (let i = 0; i < size; i++) {
       arr.push(factory(override));
     }
     return arr;
   };
-}
 
-export { array, ArrayFactory };
+  // Define a property to differentiate this function during the evaluation
+  // phase when the factory is later invoked.
+  arrayFactory.__cooky_cutter = ARRAY_FACTORY_KEY as typeof ARRAY_FACTORY_KEY;
+
+  return arrayFactory;
+}

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -4,6 +4,7 @@ import {
   isFactoryFunction
 } from "./utils";
 import { Config } from "./define";
+import { getConfig } from "./config";
 
 // Given a key, the configuration object (with overrides already applied) and
 // the end result object, compute the current value for the given key and write
@@ -44,14 +45,23 @@ function compute<
  * a warning.
  */
 const warnAboutHardCodedValues = <Key, Value>(key: Key, value: Value) => {
+  let message: string | undefined;
   if (Array.isArray(value)) {
-    console.warn(
-      `\`${key}\` contains a hard-coded array. It will be shared across all instances of this factory. Consider using a factory function.`
-    );
+    message = `\`${key}\` contains a hard-coded array.`;
   } else if (typeof value === "object" && value !== null) {
-    console.warn(
-      `\`${key}\` contains a hard-coded object. It will be shared across all instances of this factory. Consider using a factory function.`
-    );
+    message = `\`${key}\` contains a hard-coded object.`;
+  }
+
+  const { errorOnHardCodedValues } = getConfig();
+
+  if (message) {
+    message += ` It will be shared across all instances of this factory. Consider using a factory function.`;
+
+    if (errorOnHardCodedValues) {
+      throw message;
+    } else {
+      console.warn(message);
+    }
   }
 };
 

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -20,7 +20,7 @@ function compute<
   values: Values,
   result: Result,
   invocations: number,
-  path: Key[] = [],
+  path: Key[],
   override: Partial<Result> = {}
 ) {
   const value = values[key];
@@ -38,7 +38,7 @@ function compute<
     result[key] = value(invocations);
   } else {
     if (!(key in override)) {
-      warnAboutHardCodedValues([key, ...path], value);
+      warnAboutHardCodedValues(key, value);
     }
 
     result[key] = value as Result[Key];
@@ -51,12 +51,12 @@ function compute<
  * instances of a factory. Check for objects and arrays and by default display
  * a warning.
  */
-const warnAboutHardCodedValues = <Key, Value>(path: Key[], value: Value) => {
+const warnAboutHardCodedValues = <Key, Value>(key: Key, value: Value) => {
   let message: string | undefined;
   if (Array.isArray(value)) {
-    message = `\`${path.join(".")}\` contains a hard-coded array.`;
+    message = `\`${key}\` contains a hard-coded array.`;
   } else if (typeof value === "object" && value !== null) {
-    message = `\`${path.join(".")}\` contains a hard-coded object.`;
+    message = `\`${key}\` contains a hard-coded object.`;
   }
 
   const { errorOnHardCodedValues } = getConfig();

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -32,8 +32,27 @@ function compute<
   } else if (isAttributeFunction<Result[Key]>(value)) {
     result[key] = value(invocations);
   } else {
+    warnAboutHardCodedValues(key, value);
     result[key] = value as Result[Key];
   }
 }
+
+/**
+ * Explicitly setting an object or array as a value in a factory can lead to
+ * really challenging and subtle bugs since they will be shared across all
+ * instances of a factory. Check for objects and arrays and by default display
+ * a warning.
+ */
+const warnAboutHardCodedValues = <Key, Value>(key: Key, value: Value) => {
+  if (Array.isArray(value)) {
+    console.warn(
+      `\`${key}\` contains a hard-coded array. It will be shared across all instances of this factory. Consider using a factory function.`
+    );
+  } else if (typeof value === "object" && value !== null) {
+    console.warn(
+      `\`${key}\` contains a hard-coded object. It will be shared across all instances of this factory. Consider using a factory function.`
+    );
+  }
+};
 
 export { compute };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,12 +1,12 @@
-interface Config {
+interface Configuration {
   errorOnHardCodedValues: boolean;
 }
 
-let config: Config = {
+let config: Configuration = {
   errorOnHardCodedValues: false
 };
 
-export const configure = (newConfig: Config) => {
+export const configure = (newConfig: Configuration) => {
   config = newConfig;
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,13 @@
+interface Config {
+  errorOnHardCodedValues: boolean;
+}
+
+let config: Config = {
+  errorOnHardCodedValues: false
+};
+
+export const configure = (newConfig: Config) => {
+  config = newConfig;
+};
+
+export const getConfig = () => config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,15 @@
 interface Configuration {
+  /**
+   * Enabling this setting will convert throw (rather than warn) when an object
+   * or array is hard-coded in the configuration for a factory (not in the
+   * override). It's strongly discouraged to use a shared instance of an
+   * object or an array between different factory instances. If one test case
+   * modifies the object or array, the next test that relies on this factory
+   * will still have those mutations which can lead to confusing and subtle
+   * bugs or random test failures.
+   *
+   * @default false
+   */
   errorOnHardCodedValues: boolean;
 }
 
@@ -6,8 +17,18 @@ let config: Configuration = {
   errorOnHardCodedValues: false
 };
 
+/**
+ * Configure global settings to cooky-cutter. This will affect ALL factories.
+ * This should be ran once before all tests and factories so that all factories
+ * rely on the same configuration.
+ *
+ * @param newConfig - an object that represents the desired configuration
+ */
 export const configure = (newConfig: Configuration) => {
   config = newConfig;
 };
 
+/**
+ * Retrieve the current global configuration options.
+ */
 export const getConfig = () => config;

--- a/src/define.ts
+++ b/src/define.ts
@@ -1,10 +1,7 @@
 import { DerivedFunction } from "./derive";
 import { compute } from "./compute";
 import { ArrayFactory } from "./array";
-
-type ArrayElement<ArrayType> = ArrayType extends (infer ElementType)[]
-  ? ElementType
-  : never;
+import { ArrayElement } from "./utils";
 
 type Config<T> = {
   [Key in keyof T]:
@@ -61,7 +58,6 @@ function define<Result>(config: Config<Result>): Factory<Result> {
 export {
   define,
   AttributeFunction,
-  ArrayElement,
   Config,
   Factory,
   FactoryConfig,

--- a/src/define.ts
+++ b/src/define.ts
@@ -45,7 +45,7 @@ function define<Result>(config: Config<Result>): Factory<Result> {
     const values = Object.assign({}, config, override);
 
     for (let key in values) {
-      compute(key, values, result, invocations);
+      compute(key, values, result, invocations, [], override);
     }
 
     return result;
@@ -61,6 +61,7 @@ function define<Result>(config: Config<Result>): Factory<Result> {
 export {
   define,
   AttributeFunction,
+  ArrayElement,
   Config,
   Factory,
   FactoryConfig,

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -46,7 +46,7 @@ function extend<Base, Result extends Base>(
     const values = Object.assign({}, config, override) as Config<Result>;
 
     for (let key in values) {
-      compute(key, values, result, invocations);
+      compute(key, values, result, invocations, [], override);
     }
 
     return result;

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -1,5 +1,11 @@
-import { Factory, FactoryConfig, AttributeFunction, Config } from "./index";
-import { DiffProperties } from "./utils";
+import {
+  Factory,
+  FactoryConfig,
+  AttributeFunction,
+  Config,
+  ArrayFactory
+} from "./index";
+import { DiffProperties, ArrayElement } from "./utils";
 import { compute } from "./compute";
 import { DerivedFunction } from "./derive";
 import { FACTORY_FUNCTION_KEY } from "./define";
@@ -18,6 +24,7 @@ type ExtendConfig<Base, Result> = {
     | AttributeFunction<Merge<Base, Result>[Key]>
     | Factory<Merge<Base, Result>[Key]>
     | DerivedFunction<Result, Merge<Base, Result>[Key]>
+    | ArrayFactory<ArrayElement<Merge<Base, Result>[Key]>>
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { configure } from "./config";
 export {
   define,
   AttributeFunction,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { DerivedFunction, DERIVE_FUNCTION_KEY } from "./derive";
 import { Factory, AttributeFunction, FACTORY_FUNCTION_KEY } from "./define";
+import { ARRAY_FACTORY_KEY, ArrayFactoryPassThrough } from "./array";
 
 // Determine if the function is an internal derive function based on properties
 // defined on the function.
@@ -13,6 +14,14 @@ function isDerivedFunction<Base, Output>(
 // defined on the function.
 function isFactoryFunction<Base>(fn: any): fn is Factory<Base> {
   return fn && fn.__cooky_cutter === FACTORY_FUNCTION_KEY;
+}
+
+// Determine if the function is an internal array factory function based on
+// properties defined on the function.
+function isArrayFactoryFunction<Base>(
+  fn: any
+): fn is ArrayFactoryPassThrough<Base> {
+  return fn && fn.__cooky_cutter === ARRAY_FACTORY_KEY;
 }
 
 // Determine if the function is an attribute function. Since this is end-user
@@ -41,5 +50,6 @@ export {
   isAttributeFunction,
   isDerivedFunction,
   isFactoryFunction,
+  isArrayFactoryFunction,
   DiffProperties
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,10 @@ type Diff<T, U> = T extends U ? never : T;
 // into `{ b: number; }`
 type DiffProperties<T, U> = Pick<T, Diff<Keys<T>, Keys<U>>>;
 
+export type ArrayElement<ArrayType> = ArrayType extends (infer ElementType)[]
+  ? ElementType
+  : never;
+
 export {
   isAttributeFunction,
   isDerivedFunction,


### PR DESCRIPTION
### Warn (by default) or error (opt-in) when a hard-coded value is set

Resolves https://github.com/skovy/cooky-cutter/issues/10.

When an object or array is explicitly set, provide a warning but also allow throwing an error. This is recommended but will be opt-in (via `configure({ errorOnHardCodedValues: true })`) to make it easy to incrementally fix and adopt (if necessary). These issues should be easily resolved by convering to a factory function (eg: `{ key: "value" }` becomes `() => ({ key: "value" })`).

### Fix type definitions to allow using `array` with `extend`
