### PR TITLE
evalute derived field after other type of fields

### DIFF
--- a/src/__tests__/derive.test.ts
+++ b/src/__tests__/derive.test.ts
@@ -117,4 +117,17 @@ describe("derive", () => {
       "lastName cannot circularly derive itself. Check along this path: lastName->firstName->fullName->lastName"
     );
   });
+
+  test("evalutes derived field after other type of fields", () => {
+    let i = 0;
+    const user = define<User>({
+      fullName: derive<User, string>(({ age }) => `Bob ${age} Smith`, "age"),
+      firstName: "Bob",
+      lastName: "Smith",
+      age: () => i++
+    });
+
+    const result = user();
+    expect(result.fullName).toEqual(`Bob ${result.age} Smith`);
+  });
 });


### PR DESCRIPTION
This pull request fixes issue #15 
It makes order of computation fields. Derived fields always computes after other types of field.