### PR TITLE
Fix an incorrect warning when using an override with a derived value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- An incorrect warning about hard-coded values when using an override value with `derive` [#17](https://github.com/skovy/cooky-cutter/pull/17)
+
 ## [1.3.0] - 2019-05-18
 
 ### Security
@@ -20,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A configuration option `errorOnHardCodedValues` will throw (rather than warn) about hard-coded values [#12](https://github.com/skovy/cooky-cutter/pull/12)
 - Properly ignore `.vscode` config when publishing to npm in [#9](https://github.com/skovy/cooky-cutter/pull/9)
 
-## Fixed
+### Fixed
 
 - The `array` type definitions now match the `extend` type definitions [#12](https://github.com/skovy/cooky-cutter/pull/12)
 

--- a/src/__tests__/define.test.ts
+++ b/src/__tests__/define.test.ts
@@ -1,5 +1,4 @@
-import { define } from "../index";
-import { configure } from "../";
+import { define, derive, configure } from "../";
 
 type User = { firstName: string; age: number; admin?: boolean };
 type Post = { title: string; user: User; tags?: string[] };
@@ -246,6 +245,30 @@ describe("define", () => {
           age: 1
         },
         tags: ["popular", "trending"]
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test("does not warn when using derive with an override value", () => {
+      interface Child {
+        id: number;
+      }
+
+      interface Parent {
+        childId: number | null;
+        child?: Child;
+      }
+
+      const parent = define<Parent>({
+        childId: derive<Parent, number | null>(
+          ({ child }) => (child ? child.id : null),
+          "child"
+        )
+      });
+
+      parent({
+        child: { id: 1 }
       });
 
       expect(warnSpy).not.toHaveBeenCalled();

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -29,7 +29,7 @@ function compute<
   // can be defined for a given key. Unfortunately it's not truly exhaustive,
   // but would be great to update this to do true exhaustive type checking.
   if (isDerivedFunction<Result, Result[Key]>(value)) {
-    result[key] = value(result, values, invocations, path);
+    result[key] = value(result, values, invocations, path, override);
   } else if (isFactoryFunction<Result[Key]>(value)) {
     result[key] = value();
   } else if (isArrayFactoryFunction<Result[Key]>(value)) {

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -8,7 +8,8 @@ interface DerivedFunction<Base, Output> {
     result: Base,
     values: Config<Base>,
     invocations: number,
-    path: (keyof Base)[]
+    path: (keyof Base)[],
+    override: Partial<Base>
   ): Output;
   __cooky_cutter: typeof DERIVE_FUNCTION_KEY;
 }
@@ -34,7 +35,8 @@ function derive<Base, Output>(
     result,
     values,
     invocations,
-    path
+    path,
+    override
   ) {
     // Construct the input object from all of the dependent values that are
     // needed to derive the value.
@@ -51,7 +53,7 @@ function derive<Base, Output>(
             )}->${key}`;
           }
 
-          compute(key, values, result, invocations, [...path, key]);
+          compute(key, values, result, invocations, [...path, key], override);
         }
 
         input[key] = result[key];


### PR DESCRIPTION
Resolves https://github.com/skovy/cooky-cutter/issues/14.

Since overrides are expected to have "hardcoded" values, there's an explicit check to ensure the value is _not_ in the overrides before warning about "hardcoded" values. However, when using `derive` the `overrides` was not getting passed along so it was always empty so the check always passed (the check that it's not in overrides).