### PR TITLE
Values should only be computed once per invocation (fixes an issue with derived values)

### DIFF
--- a/src/__tests__/derive.test.ts
+++ b/src/__tests__/derive.test.ts
@@ -117,4 +117,37 @@ describe("derive", () => {
       "lastName cannot circularly derive itself. Check along this path: lastName->firstName->fullName->lastName"
     );
   });
+
+  test("only invokes a function once when deriving", () => {
+    interface Child {
+      id: number;
+    }
+
+    interface Parent {
+      childId: number | null;
+      child?: Child;
+    }
+
+    const child = define<Child>({
+      id: sequence
+    });
+
+    const parent = define<Parent>({
+      childId: derive<Parent, number | null>(
+        ({ child }) => (child ? child.id : null),
+        "child"
+      )
+    });
+
+    expect(
+      parent({
+        child
+      })
+    ).toEqual({
+      childId: 1,
+      child: {
+        id: 1
+      }
+    });
+  });
 });

--- a/src/define.ts
+++ b/src/define.ts
@@ -39,10 +39,11 @@ function define<Result>(config: Config<Result>): Factory<Result> {
     invocations++;
 
     let result = {} as Result;
+    let computedKeys: Array<keyof Result> = [];
     const values = Object.assign({}, config, override);
 
     for (let key in values) {
-      compute(key, values, result, invocations, [], override);
+      compute(key, values, result, invocations, [], override, computedKeys);
     }
 
     return result;

--- a/src/derive.ts
+++ b/src/derive.ts
@@ -9,7 +9,8 @@ interface DerivedFunction<Base, Output> {
     values: Config<Base>,
     invocations: number,
     path: (keyof Base)[],
-    override: Partial<Base>
+    override: Partial<Base>,
+    computedKeys: Array<keyof Base>
   ): Output;
   __cooky_cutter: typeof DERIVE_FUNCTION_KEY;
 }
@@ -36,7 +37,8 @@ function derive<Base extends object, Output>(
     values,
     invocations,
     path,
-    override
+    override,
+    computedKeys
   ) {
     // Construct the input object from all of the dependent values that are
     // needed to derive the value.
@@ -53,7 +55,15 @@ function derive<Base extends object, Output>(
             )}->${key}`;
           }
 
-          compute(key, values, result, invocations, [...path, key], override);
+          compute(
+            key,
+            values,
+            result,
+            invocations,
+            [...path, key],
+            override,
+            computedKeys
+          );
         }
 
         input[key] = result[key];

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -28,7 +28,7 @@ type ExtendConfig<Base, Result> = {
 };
 
 /**
- * Define a new factory function from an existing fatory. The return value is a
+ * Define a new factory function from an existing factory. The return value is a
  * function that can be invoked as many times as needed to create a given type
  * of object. Use the config param to define how the object is generated on each
  * invocation.
@@ -47,13 +47,17 @@ function extend<Base, Result extends Base>(
   const factory = (override = {}) => {
     invocations++;
     let result = base(override as FactoryConfig<Base>) as Result;
+    // The computed keys starts empty (rather than including the base result
+    // keys) because those values should get overridden and recomputed by the
+    // extended values.
+    let computedKeys: Array<keyof Result> = [];
 
     // TODO: this cast is necessary for the correct `key` typings and playing
     // nice with `compute`. Ideally, this can be avoided.
     const values = Object.assign({}, config, override) as Config<Result>;
 
     for (let key in values) {
-      compute(key, values, result, invocations, [], override);
+      compute(key, values, result, invocations, [], override, computedKeys);
     }
 
     return result;


### PR DESCRIPTION
Resolves https://github.com/skovy/cooky-cutter/issues/15.

When `derive` is invoked, it must find all dependencies and compute those values first (before the derived function can be called with those values). However, if those values are then later hit they will be re-computed (even though the `derive` already computed them). 

